### PR TITLE
Feature/token set nf

### DIFF
--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -16,8 +16,7 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Literal, Optional, Union, List
-
+from typing import Any, Literal, Optional
 
 @dataclass
 class DataArguments:

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, Union, List
 
 
 @dataclass
@@ -123,13 +123,14 @@ class DataArguments:
         default=True,
         metadata={"help": "Whether or not to enable thinking mode for reasoning models."},
     )
-    tokenized_path: Optional[str] = field(
+    tokenized_path: Optional[Union[str, list[str]]] = field(
         default=None,
         metadata={
             "help": (
                 "Path to save or load the tokenized datasets. "
                 "If tokenized_path not exists, it will save the tokenized datasets. "
                 "If tokenized_path exists, it will load the tokenized datasets."
+                "If passing a list of paths, it will load each of the tokenized datasets"
             )
         },
     )

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -123,7 +123,7 @@ class DataArguments:
         default=True,
         metadata={"help": "Whether or not to enable thinking mode for reasoning models."},
     )
-    tokenized_path: Optional[Union[str, list[str]]] = field(
+    tokenized_path: Optional[Any] = field(
         default=None,
         metadata={
             "help": (

--- a/src/llamafactory/hparams/parser.py
+++ b/src/llamafactory/hparams/parser.py
@@ -251,7 +251,7 @@ def get_train_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> _
     if training_args.max_steps == -1 and data_args.streaming:
         raise ValueError("Please specify `max_steps` in streaming mode.")
 
-    if training_args.do_train and data_args.dataset is None:
+    if training_args.do_train and (data_args.dataset is None) and (data_args.tokenized_path is None):
         raise ValueError("Please specify dataset for training.")
 
     if (training_args.do_eval or training_args.do_predict) and (


### PR DESCRIPTION
Added supported for a list of token sets. Limited to arrow files (produced by save_to_disk) and train datasets only.
